### PR TITLE
Loggers with duration need to use milliseconds

### DIFF
--- a/lib/appydays/loggable/sequel_logger.rb
+++ b/lib/appydays/loggable/sequel_logger.rb
@@ -17,7 +17,11 @@ class Sequel::Database
     log_each(
       :info,
       proc { args ? "#{message}; #{args.inspect}" : message },
-      proc { ["sequel_log", {message: message, args: args}] },
+      proc do
+        o = {message: message}
+        o[:args] = args unless args.nil?
+        ["sequel_log", o]
+      end,
     )
   end
 

--- a/lib/appydays/loggable/sequel_logger.rb
+++ b/lib/appydays/loggable/sequel_logger.rb
@@ -28,7 +28,7 @@ class Sequel::Database
     log_each(
       lwd && (duration >= lwd) ? :warn : sql_log_level,
       proc { "(#{'%0.6fs' % duration}) #{message}" },
-      proc { ["sequel_query", {duration: duration, query: message}] },
+      proc { ["sequel_query", {duration: duration * 1000, query: message}] },
     )
   end
 

--- a/lib/appydays/loggable/sidekiq_job_logger.rb
+++ b/lib/appydays/loggable/sidekiq_job_logger.rb
@@ -43,10 +43,10 @@ class Appydays::Loggable::SidekiqJobLogger < Sidekiq::JobLogger
     yield
     duration = self.elapsed(start)
     log_method = duration >= self.slow_job_seconds ? :warn : :info
-    self.logger.send(log_method, "job_done", duration: duration)
+    self.logger.send(log_method, "job_done", duration: duration * 1000)
   rescue StandardError
     # Do not log the error since it is probably a sidekiq retry error
-    self.logger.error("job_fail", duration: self.elapsed(start))
+    self.logger.error("job_fail", duration: self.elapsed(start) * 1000)
     raise
   end
 

--- a/spec/appydays/loggable_spec.rb
+++ b/spec/appydays/loggable_spec.rb
@@ -223,6 +223,17 @@ RSpec.describe Appydays::Loggable do
       )
     end
 
+    it "logs duration properly (SemanticLogger uses milliseconds)" do
+      lines = log { sleep(0.001) }
+      expect(lines).to contain_exactly(
+        include_json(
+          message: "job_done",
+          duration: start_with("1.").and(end_with("ms")),
+          duration_ms: be >= 1,
+        ),
+      )
+    end
+
     it "logs at warn if the time taken is more than the slow job seconds" do
       @slow_secs = 0
       lines = log


### PR DESCRIPTION
SemanticLogger uses milliseconds for logging,
not seconds, which is non-idiomatic Ruby but whatever.

Add specs for sequel logger
