### PR TITLE
Improve and test spec helpers

### DIFF
--- a/appydays.gemspec
+++ b/appydays.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"]
   s.add_dependency("dotenv", "~> 2.7")
   s.add_dependency("semantic_logger", "~> 4.6")
+  s.add_development_dependency("monetize", "~> 1.0")
+  s.add_development_dependency("money", "~> 6.0")
   s.add_development_dependency("rack", "~> 2.2")
   s.add_development_dependency("rspec", "~> 3.10")
   s.add_development_dependency("rspec-core", "~> 3.10")

--- a/lib/appydays/spec_helpers.rb
+++ b/lib/appydays/spec_helpers.rb
@@ -25,6 +25,7 @@ module Appydays::SpecHelpers
 
     def matches?(target)
       @target = target
+      @target = @target.lines if @target.is_a?(String)
       return @target.find do |obj|
         obj.to_s.match(@regexp)
       end
@@ -43,9 +44,9 @@ module Appydays::SpecHelpers
     alias failure_message_for_should_not failure_message_when_negated
   end
 
-  ### RSpec matcher -- set up the expectation that the lefthand side
-  ### is Enumerable, and that at least one of the objects yielded
-  ### while iterating matches +regexp+ when converted to a String.
+  # RSpec matcher -- set up the expectation that the lefthand side
+  # is Enumerable, and that at least one of the objects yielded
+  # while iterating matches +regexp+ when converted to a String.
   module_function def have_a_line_matching(regexp)
     return HaveALineMatching.new(regexp)
   end
@@ -54,39 +55,70 @@ module Appydays::SpecHelpers
     return RSpec::Matchers::BuiltIn::HaveAttributes.new(length: x)
   end
 
+  class MatchTime
+    def initialize(expected)
+      @expected = expected
+      if expected == :now
+        @expected_t = Time.now
+        @tolerance = 5
+      else
+        @expected_t = self.time(expected)
+        @tolerance = 0.001
+      end
+    end
+
+    def time(s)
+      return nil if s.nil?
+      return Time.parse(s) if s.is_a?(String)
+      return s.to_time
+    end
+
+    def matches?(actual)
+      @actual_t = self.time(actual)
+      @actual_t = self.change_tz(@actual_t, @expected_t.zone) if @actual_t
+      return RSpec::Matchers::BuiltIn::BeWithin.new(@tolerance).of(@expected_t).matches?(@actual_t)
+    end
+
+    protected def change_tz(t, zone)
+      return t.change(zone: zone) if t.respond_to?(:change)
+      prev_tz = ENV.fetch("TZ", nil)
+      begin
+        ENV["TZ"] = zone
+        return Time.at(t.to_f)
+      ensure
+        ENV["TZ"] = prev_tz
+      end
+    end
+
+    def within(tolerance)
+      @tolerance = tolerance
+      return self
+    end
+
+    def failure_message
+      return "expected %s to be within %s of %s" % [@actual_t, @tolerance, @expected_t]
+    end
+  end
+
   # Matcher that will compare a string or time expected against a string or time actual,
   # within a tolerance (default to 1 millisecond).
+  #
+  # Use match_time(:now) to automatically `match_time(Time.now).within(5.seconds)`.
   #
   #   expect(last_response).to have_json_body.that_includes(
   #       closes_at: match_time('2025-12-01T00:00:00.000+00:00').within(1.second))
   #
-  RSpec::Matchers.define(:match_time) do |expected|
-    match do |actual|
-      @tolerance ||= 0.001
-      RSpec::Matchers::BuiltIn::BeWithin.new(@tolerance).of(self.time(expected)).matches?(self.time(actual))
-    end
-
-    failure_message do |actual|
-      "expected ids %s to be within %s of %s" % [self.time(actual), @tolerance, self.time(expected)]
-    end
-
-    chain :within do |tolerance|
-      @tolerance = tolerance
-    end
-
-    def time(s)
-      return Time.parse(s) if s.is_a?(String)
-      return s.to_time
-    end
+  def match_time(expected)
+    return MatchTime.new(expected)
   end
 
   # Matcher that will compare a string or Money expected against a string or Money actual.
   #
   #   expect(order.total).to cost('$25')
   #
-  RSpec::Matchers.define(:cost) do |expected|
+  RSpec::Matchers.define(:cost) do |expected, currency|
     match do |actual|
-      @base = RSpec::Matchers::BuiltIn::Eq.new(self.money(expected))
+      @base = RSpec::Matchers::BuiltIn::Eq.new(self.money(expected, currency))
       @base.matches?(self.money(actual))
     end
 
@@ -94,12 +126,37 @@ module Appydays::SpecHelpers
       @base.failure_message
     end
 
-    def money(s)
-      return Monetize.parse(s) if s.is_a?(String)
+    def money(s, currency=nil)
+      if (m = self.tryparse(s, currency))
+        return m
+      end
       return s if s.is_a?(Money)
-      return Money.new(s) if s.is_a?(Integer)
+      return Money.new(s, currency) if s.is_a?(Integer)
       return Money.new(s[:cents], s[:currency]) if s.respond_to?(:key?) && s.key?(:cents) && s.key?(:currency)
       raise "#{s} type #{s.class.name} not convertable to Money (add support or use supported type)"
+    end
+
+    def tryparse(s, currency)
+      # We need to capture some global settings while we parse, and set them back after.
+      orig_default = Money.instance_variable_get(:@default_currency)
+      orig_assume = Monetize.assume_from_symbol
+      return nil unless s.is_a?(String)
+      # See https://github.com/RubyMoney/monetize/issues/161
+      # To get around this, need to use a valid custom currency
+      begin
+        Money::Currency.new("APPYDAYS")
+      rescue Money::Currency::UnknownCurrency
+        Money::Currency.register(iso_code: "APPYDAYS", subunit_to_unit: 1)
+      end
+      Money.default_currency = currency || orig_default || "APPYDAYS"
+      Monetize.assume_from_symbol = true
+      m = Monetize.parse!(s)
+      return m unless m.currency == "APPYDAYS"
+      raise Money::Currency::UnknownCurrency,
+            "Could not parse currency from '#{s}'. It needs a symbol, or set default_currency."
+    ensure
+      Money.default_currency = orig_default
+      Monetize.assume_from_symbol = orig_assume
     end
   end
 end

--- a/spec/appydays/spec_helpers_spec.rb
+++ b/spec/appydays/spec_helpers_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "appydays/spec_helpers"
+
+RSpec.describe Appydays::SpecHelpers do
+  describe "have_a_line_matching" do
+    it "matches lines" do
+      lines = "abc\ndef\nghi"
+      expect(lines).to have_a_line_matching(/def/)
+      expect(lines.lines).to have_a_line_matching(/def/)
+      expect(lines).to_not have_a_line_matching(/xyz/)
+      expect(lines.lines).to_not have_a_line_matching(/xyz/)
+    end
+  end
+
+  describe "have_length" do
+    it "matches length" do
+      expect([]).to have_length(0)
+      expect([1]).to have_length(1)
+      expect([1, 1]).to have_length(2)
+      expect([]).to_not have_length(2)
+      expect([1, 2, 3]).to_not have_length(2)
+    end
+  end
+
+  describe "cost" do
+    before(:all) do
+      require "money"
+      require "monetize"
+      Money.rounding_mode = BigDecimal::ROUND_HALF_UP
+    end
+    before(:each) do
+      Money.default_currency = nil
+      Monetize.assume_from_symbol = false
+    end
+    it "compares cost" do
+      m = Money.new(100, "USD")
+      expect(m).to cost("$1")
+      expect(m).to cost("$1.00")
+      expect(m).to_not cost("$1.01")
+      expect(m).to cost(Money.new(100, "USD"))
+      expect(m).to_not cost(Money.new(101, "USD"))
+      expect(m).to cost(100, "USD")
+      expect(m).to_not cost(101, "USD")
+    end
+    it "can work with default currency" do
+      m = Money.new(100, "USD")
+      Money.default_currency = "USD"
+      expect(m).to cost("1")
+      expect(m).to cost("1.00")
+      expect(m).to_not cost("1.01")
+      expect(m).to cost(100)
+      expect(m).to_not cost(101)
+    end
+
+    it "errors if no currency can be found" do
+      m = Money.new(100, "USD")
+      expect { expect(m).to cost(100) }.to raise_error(Money::Currency::UnknownCurrency)
+      expect { expect(m).to cost("1") }.to raise_error(Money::Currency::UnknownCurrency, /Could not parse/)
+    end
+  end
+
+  describe "match_time" do
+    t = Time.parse("2025-10-01T5:10:20.456789-07:00")
+    it "matches time" do
+      expect(t).to match_time(t)
+      expect(t).to match_time(t + 0.0001)
+      expect(t).to_not match_time(t + 1)
+      expect(t).to match_time(t + 2).within(5)
+
+      expect(t).to match_time("2025-10-01T5:10:20.456789-07:00")
+      expect(t).to match_time("2025-10-01T4:10:20.456789-08:00")
+    end
+
+    it "matches now" do
+      expect(Time.now + 2).to match_time(:now)
+      expect(Time.now).to match_time(:now)
+      expect(Time.now - 6).to_not match_time(:now)
+    end
+  end
+end


### PR DESCRIPTION
- Add tests for all spec helpers
- match_time supports a special :now option
- have_a_line_matching can take a string, calls `lines`
- cost handles no default currency correctly