### PR TITLE
Do not log Sequel table exists at error, and support an array of env keys

### DIFF
--- a/lib/appydays/configurable.rb
+++ b/lib/appydays/configurable.rb
@@ -86,6 +86,8 @@ module Appydays::Configurable
     #   If convert is passed, that is used as the converter so the default value can be any type.
     # key: The key to lookup the config value from the environment.
     #   If nil, use an auto-generated combo of the configuration key and method name.
+    #   If key is an array, look up each (string) value as a key.
+    #   The first non-nil (ie, `ENV.fetch(x, nil)`) value will be used.
     # convert: If provided, call it with the string value so it can be parsed.
     #   For example, you can parse a string JSON value here.
     #   Convert will not be called with the default value.
@@ -106,7 +108,8 @@ module Appydays::Configurable
       end
 
       key ||= "#{@group_key}_#{name}".upcase
-      env_value = ENV.fetch(key, nil)
+      keys = Array(key)
+      env_value = keys.filter_map { |k| ENV.fetch(k, nil) }.first
       converter = self._converter(default, convert)
       value = env_value.nil? ? default : converter[env_value]
       value = installer._set_value(name, value, side_effect)

--- a/lib/appydays/loggable/sequel_logger.rb
+++ b/lib/appydays/loggable/sequel_logger.rb
@@ -5,8 +5,9 @@ require "sequel/database/logging"
 
 class Sequel::Database
   def log_exception(exception, message)
+    level = message.match?(/^SELECT NULL AS "?nil"? FROM .* LIMIT 1$/i) ? :debug : :error
     log_each(
-      :error,
+      level,
       proc { "#{exception.class}: #{exception.message.strip if exception.message}: #{message}" },
       proc { ["sequel_exception", {sequel_message: message}, exception] },
     )

--- a/spec/appydays/configurable_spec.rb
+++ b/spec/appydays/configurable_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Appydays::Configurable do
+  before(:each) do
+    @orig_keys = ENV.keys
+  end
+  after(:each) do
+    ENV.delete_if { |k| !@orig_keys.include?(k) }
+  end
   describe "configurable" do
     it "raises if no block is given" do
       expect do
@@ -42,6 +48,28 @@ RSpec.describe Appydays::Configurable do
           end
         end
         expect(cls).to have_attributes(knob: "two")
+      end
+
+      it "can use an array of environment keys" do
+        ENV["KNOB2"] = "two"
+        ENV["KNOB3"] = "three"
+        cls = Class.new do
+          include Appydays::Configurable
+          configurable(:hello) do
+            setting :knob, "zero", key: ["KNOB1", "KNOB2", "KNOB3"]
+          end
+        end
+        expect(cls).to have_attributes(knob: "two")
+      end
+
+      it "can use a default if no env keys are found" do
+        cls = Class.new do
+          include Appydays::Configurable
+          configurable(:hello) do
+            setting :knob, "zero", key: ["KNOB1", "KNOB2"]
+          end
+        end
+        expect(cls).to have_attributes(knob: "zero")
       end
 
       it "can convert the value given the converter" do

--- a/spec/appydays/loggable_spec.rb
+++ b/spec/appydays/loggable_spec.rb
@@ -308,6 +308,17 @@ RSpec.describe Appydays::Loggable do
         )
       end
 
+      it "logs 'table exists' exceptions at debug" do
+        lines = log do |db|
+          db.log_exception(RuntimeError.new("nope"), "SELECT NULL AS nil FROM sch.foobar LIMIT 1")
+          db.log_exception(RuntimeError.new("nope"), "select null as \"nil\" FROM \"sch\".\"foobar\" LIMIT 1")
+        end
+        expect(lines).to contain_exactly(
+          include_json(level: "debug", message: "sequel_exception"),
+          include_json(level: "debug", message: "sequel_exception"),
+        )
+      end
+
       it "logs duration" do
         lines = log do |db|
           db.log_duration(4, "slow")


### PR DESCRIPTION
Do not log Sequel 'table exists' exceptions at error

Sequel issues a query that will error if a table does not exist;
this gets caught and logged out as an error.
But this isn't really an exception, so we can ignore it.

---

Allow setting keys to be an array, to support fallbacks
