### PR TITLE
Default RACK_ENV within Dotenviable.load

### DIFF
--- a/lib/appydays/dotenviable.rb
+++ b/lib/appydays/dotenviable.rb
@@ -9,8 +9,17 @@ require "appydays/version"
 # (by convention, .env.<env>.local, .env.<env>, and .env).
 #
 # It can be called multiple times for the same environment.
+# There are a couple special cases for RACK_ENV and PORT variables:
 #
-# NOTE: Foreman assigns the $PORT environment variable BEFORE we load config
+# RACK_ENV variable: Dotenviable defaults the $RACK_ENV variable to whatever
+# is used for dotfile loading (ie, the `rack_env` or `default_rack_env` value).
+# This avoids the surprising behavior where a caller does not have RACK_ENV set,
+# they call +Dotenviable.load+, and RACK_ENV is still not set,
+# though it had some implied usage within this method.
+# If for some reason you do not want +ENV['RACK_ENV']+ to be set,
+# you can store its value before calling `load` and set it back after.
+#
+# PORT variable: Foreman assigns the $PORT environment variable BEFORE we load config
 # (get to what is defined in worker, like puma.rb), so even if we have it in the .env files,
 # it won't get used, because .env files don't stomp what is already in the environment
 # (we don't want to use `overload`).
@@ -26,5 +35,6 @@ module Appydays::Dotenviable
     ]
     Dotenv.load(*paths)
     env["PORT"] ||= original_port
+    env["RACK_ENV"] ||= rack_env
   end
 end

--- a/spec/appydays/dotenviable_spec.rb
+++ b/spec/appydays/dotenviable_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe Appydays::Dotenviable do
     expect(env).to include("PORT" => "123")
   end
 
+  it "defaults RACK_ENV to what was used for loading" do
+    env = {"RACK_ENV" => "original"}
+    expect(Dotenv).to receive(:load)
+    described_class.load(env: env)
+    expect(env).to include("RACK_ENV" => "original")
+
+    env = {}
+    expect(Dotenv).to receive(:load)
+    described_class.load(env: env, default_rack_env: "xyz")
+    expect(env).to include("RACK_ENV" => "xyz")
+  end
+
   it "does not reapply the original port if one was loaded" do
     env = {"PORT" => "123"}
     expect(Dotenv).to receive(:load) { env["PORT"] = "456" }


### PR DESCRIPTION
Avoid the surprising situation where it isn't set,
even though it was implicitly used to load the dotfiles.