### PR TITLE
Add HTTParty formatter; truncate long Sequel logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,13 @@ We love [Sequel](https://github.com/jeremyevans/sequel) and can set your DB logs
 require "appydays/loggable/sequel_logger"
 ```
 
+Note that, by default, very long log messages (> 2000 characters) are truncated,
+and the untruncated message is logged at debug.
+
+You can control this behavior, including the size cutoff, truncation message,
+context, and loging of the untruncated message. Refer to `Sequel::Database::AppydaysLogger`
+for information.
+
 ### Request Loggers
 
 Structured request logging!

--- a/README.md
+++ b/README.md
@@ -225,5 +225,15 @@ Sidekiq.configure_server do |config|
   config.error_handlers.replace([AppJobLogger::JobLogger.method(:error_handler)])
   config.death_handlers << AppJobLogger::JobLogger.method(:death_handler)
 end
+```
 
+
+### HTTParty
+
+Well structured logs for HTTParty!
+
+```rb
+require 'appydays/loggable/httparty_formatter'
+logger = SemanticLogger["my_app_logger"]
+HTTParty.post("https://foo/bar", body: {x: 1}, logger: logger, log_format: :appydays)
 ```

--- a/appydays.gemspec
+++ b/appydays.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"]
   s.add_dependency("dotenv", "~> 2.7")
   s.add_dependency("semantic_logger", "~> 4.6")
+  s.add_development_dependency("httparty", "~> 0.20")
   s.add_development_dependency("monetize", "~> 1.0")
   s.add_development_dependency("money", "~> 6.0")
   s.add_development_dependency("rack", "~> 2.2")
@@ -29,5 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-sequel", "~> 0.2")
   s.add_development_dependency("sequel", "~> 5.0")
   s.add_development_dependency("sidekiq", "~> 6.0")
+  s.add_development_dependency("webmock", "~> 3.1")
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/lib/appydays/loggable/httparty_formatter.rb
+++ b/lib/appydays/loggable/httparty_formatter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "httparty"
+
+# Formatter that sends structred log information to HTTParty.
+# After requiring this module, use
+# `HTTParty.<method>(..., logger: semantic_logger, log_format: :appydays)`
+# to write out a nice structured log.
+# You can also subclass this formatter to use your own message (default to httparty_request),
+# and modify the fields (override #fields).
+class Appydays::Loggable::HTTPartyFormatter
+  attr_accessor :level, :logger, :message
+  attr_reader :request, :response
+
+  def initialize(logger, level)
+    @logger = logger
+    @level  = level.to_sym
+    @message = "httparty_request"
+  end
+
+  def format(request, response)
+    @request = request
+    @response = response
+    self.logger.public_send(self.level, self.message, **self.fields)
+  end
+
+  def fields
+    return {
+      "content_length" => content_length || "-",
+      "http_method" => http_method,
+      "path" => path,
+      "response_code" => response.code,
+    }
+  end
+
+  def http_method
+    @http_method ||= request.http_method.name.split("::").last.upcase
+  end
+
+  def path
+    @path ||= request.path.to_s
+  end
+
+  def content_length
+    @content_length ||= response.respond_to?(:headers) ? response.headers["Content-Length"] : response["Content-Length"]
+  end
+end
+
+HTTParty::Logger.add_formatter(:appydays, Appydays::Loggable::HTTPartyFormatter)

--- a/lib/appydays/loggable/sequel_logger.rb
+++ b/lib/appydays/loggable/sequel_logger.rb
@@ -4,6 +4,32 @@
 require "sequel/database/logging"
 
 class Sequel::Database
+  # Helpers for the Appydays Sequel logger.
+  # Very long messages may end up getting logged; the logger will truncate anything
+  # longer than +truncate_messages_over+, with +truncation_context+ number of chars
+  # at the beginning and at the end.
+  #
+  # If a message is truncated, the full message is logged at +log_full_message_level+ (default :debug).
+  # Use nil to disable the full message logging.
+  module AppydaysLogger
+    class << self
+      attr_accessor :truncate_messages_over, :truncation_message, :truncation_context, :log_full_message_level
+
+      def setdefaults
+        @truncate_messages_over = 2000
+        @truncation_message = "<truncated, full message logged at debug>"
+        @truncation_context = 200
+      end
+
+      def truncate_message(message)
+        return message if message.size <= self.truncate_messages_over
+        msg = message[...self.truncation_context] + self.truncation_message + message[-self.truncation_context..]
+        return msg
+      end
+    end
+  end
+  AppydaysLogger.setdefaults
+
   def log_exception(exception, message)
     level = message.match?(/^SELECT NULL AS "?nil"? FROM .* LIMIT 1$/i) ? :debug : :error
     log_each(
@@ -30,10 +56,25 @@ class Sequel::Database
   # warn level if duration is greater than log_warn_duration.
   def log_duration(duration, message)
     lwd = log_warn_duration
+    was_truncated = false
     log_each(
       lwd && (duration >= lwd) ? :warn : sql_log_level,
       proc { "(#{'%0.6fs' % duration}) #{message}" },
-      proc { ["sequel_query", {duration: duration * 1000, query: message}] },
+      proc do
+        query = AppydaysLogger.truncate_message(message)
+        params = {duration: duration * 1000, query: query}
+        if query != message
+          params[:truncated] = true
+          was_truncated = true
+        end
+        ["sequel_query", params]
+      end,
+    )
+    return unless was_truncated && Sequel::Database::AppydaysLogger.log_full_message_level
+    log_each(
+      Sequel::Database::AppydaysLogger.log_full_message_level,
+      nil,
+      proc { ["sequel_query_debug", {duration: duration * 1000, query: message}] },
     )
   end
 
@@ -41,7 +82,7 @@ class Sequel::Database
     @loggers.each do |logger|
       if logger.is_a?(SemanticLogger::Base)
         logger.public_send(level, *semantic.call)
-      else
+      elsif std
         logger.public_send(level, std.call)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,10 @@ require "appydays/loggable/spec_helpers"
 require "appydays/spec_helpers"
 require "appydays/configurable"
 
+require "webmock/rspec"
+
+WebMock.disable_net_connect!
+
 RSpec.configure do |config|
   # config.full_backtrace = true
 


### PR DESCRIPTION
Sequel logger truncates long messages

---

Add HTTParty log formatter

So HTTParty plays nicer with SemanticLogger.
