### PR TITLE
Add :json_trunc log formatter

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1']
+        ruby: ['3.1', '3.2', '3.3']
         gemfile: ['Gemfile', 'Gemfile.oldgems', 'Gemfile.sentry']
     runs-on: ubuntu-latest
     env:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
   - rubocop-sequel
 
 AllCops:
+  TargetRubyVersion: 3.1
   NewCops: enable
   SuggestExtensions: false
 

--- a/appydays.gemspec
+++ b/appydays.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-sequel", "~> 0.3.4")
   s.add_development_dependency("sequel", "~> 5.0")
   s.add_development_dependency("sidekiq", "~> 6.0")
+  s.add_development_dependency("simplecov", "~> 0.22")
   s.add_development_dependency("webmock", "~> 3.1")
   s.metadata["rubygems_mfa_required"] = "true"
 end

--- a/appydays.gemspec
+++ b/appydays.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.author = "Lithic Tech"
   s.homepage = "https://github.com/lithictech/appydays"
   s.licenses = "MIT"
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.1.0"
   s.description = <<~DESC
     appydays provides support for env-based configuration, and common structured logging capabilities
   DESC

--- a/lib/appydays/loggable.rb
+++ b/lib/appydays/loggable.rb
@@ -94,8 +94,8 @@ module Appydays::Loggable
   end
 
   module Methods
-    def with_log_tags(tags, &block)
-      return SemanticLogger.named_tagged(tags, &block)
+    def with_log_tags(tags, &)
+      return SemanticLogger.named_tagged(tags, &)
     end
   end
 end

--- a/lib/appydays/loggable/sequel_logger.rb
+++ b/lib/appydays/loggable/sequel_logger.rb
@@ -45,7 +45,7 @@ class Sequel::Database
       :info,
       proc { args ? "#{message}; #{args.inspect}" : message },
       proc do
-        o = {message: message}
+        o = {message:}
         o[:args] = args unless args.nil?
         ["sequel_log", o]
       end,
@@ -62,7 +62,7 @@ class Sequel::Database
       proc { "(#{'%0.6fs' % duration}) #{message}" },
       proc do
         query = AppydaysLogger.truncate_message(message)
-        params = {duration: duration * 1000, query: query}
+        params = {duration: duration * 1000, query:}
         if query != message
           params[:truncated] = true
           was_truncated = true

--- a/lib/appydays/loggable/sidekiq_job_logger.rb
+++ b/lib/appydays/loggable/sidekiq_job_logger.rb
@@ -20,7 +20,7 @@ class Appydays::Loggable::SidekiqJobLogger < Sidekiq::JobLogger
 
   Sidekiq.logger = self.logger
 
-  def call(item, _queue, &block)
+  def call(item, _queue, &)
     start = self.now
     tags = {
       job_class: item["class"],
@@ -28,7 +28,7 @@ class Appydays::Loggable::SidekiqJobLogger < Sidekiq::JobLogger
       thread_id: self.tid,
     }
     self.with_log_tags(tags) do
-      self.call_inner(start, &block)
+      self.call_inner(start, &)
     end
   end
 

--- a/lib/appydays/loggable/spec_helpers.rb
+++ b/lib/appydays/loggable/spec_helpers.rb
@@ -36,7 +36,7 @@ module Appydays::Loggable::SpecHelpers
     loggers.each { |log| log.level = level }
 
     io = StringIO.new
-    appender = SemanticLogger.add_appender(io: io, level: level)
+    appender = SemanticLogger.add_appender(io:, level:)
     appender.formatter = formatter if formatter
     begin
       yield

--- a/lib/appydays/spec_helpers.rb
+++ b/lib/appydays/spec_helpers.rb
@@ -85,7 +85,7 @@ module Appydays::SpecHelpers
     end
 
     protected def change_tz(t, zone)
-      return t.change(zone: zone) if t.respond_to?(:change)
+      return t.change(zone:) if t.respond_to?(:change)
       prev_tz = ENV.fetch("TZ", nil)
       begin
         ENV["TZ"] = zone

--- a/spec/appydays/dotenviable_spec.rb
+++ b/spec/appydays/dotenviable_spec.rb
@@ -24,26 +24,26 @@ RSpec.describe Appydays::Dotenviable do
   it "reapplies the original port if one was not loaded" do
     env = {"PORT" => "123"}
     expect(Dotenv).to receive(:load)
-    described_class.load(env: env)
+    described_class.load(env:)
     expect(env).to include("PORT" => "123")
   end
 
   it "defaults RACK_ENV to what was used for loading" do
     env = {"RACK_ENV" => "original"}
     expect(Dotenv).to receive(:load)
-    described_class.load(env: env)
+    described_class.load(env:)
     expect(env).to include("RACK_ENV" => "original")
 
     env = {}
     expect(Dotenv).to receive(:load)
-    described_class.load(env: env, default_rack_env: "xyz")
+    described_class.load(env:, default_rack_env: "xyz")
     expect(env).to include("RACK_ENV" => "xyz")
   end
 
   it "does not reapply the original port if one was loaded" do
     env = {"PORT" => "123"}
     expect(Dotenv).to receive(:load) { env["PORT"] = "456" }
-    described_class.load(env: env)
+    described_class.load(env:)
     expect(env).to include("PORT" => "456")
   end
 

--- a/spec/appydays/loggable_spec.rb
+++ b/spec/appydays/loggable_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Appydays::Loggable do
       lines = run_app(proc do
         expect(env).to(include("HTTP_TRACE_ID"))
         [200, {}, ""]
-      end, env: env,)
+      end, env:,)
       expect(lines).to have_a_line_matching(/"trace_id":"[0-9a-z]{8}-/)
     end
   end
@@ -306,7 +306,7 @@ RSpec.describe Appydays::Loggable do
     describe "with structure logging" do
       def log
         logger = SemanticLogger[Sequel]
-        db = Sequel.connect("mock://", logger: logger, log_warn_duration: 3)
+        db = Sequel.connect("mock://", logger:, log_warn_duration: 3)
         return capture_logs_from(logger, formatter: :json) do
           yield(db)
         end
@@ -439,7 +439,7 @@ RSpec.describe Appydays::Loggable do
       def log
         device = StringIO.new
         logger = Logger.new(device)
-        db = Sequel.connect("mock://", logger: logger, log_warn_duration: 3)
+        db = Sequel.connect("mock://", logger:, log_warn_duration: 3)
         yield(db)
         return device.string
       end
@@ -482,7 +482,7 @@ RSpec.describe Appydays::Loggable do
       logger = SemanticLogger["http_spec_logging_test"]
       stub_request(:post, "https://foo/bar").to_return(status: 200, body: "")
       logs = capture_logs_from(logger, formatter: :json) do
-        HTTParty.post("https://foo/bar", body: {x: 1}, logger: logger, log_format: :appydays)
+        HTTParty.post("https://foo/bar", body: {x: 1}, logger:, log_format: :appydays)
       end
       expect(logs).to contain_exactly(
         include_json(


### PR DESCRIPTION
SemanticLogger Formatter that truncates large strings in the structured log payload.
If the emitted JSON log is longer than +max_message_len+:
- the payload is walked,
- any strings with a length greater than +max_string_len+ are shortened using +shorten_string+.
  Override +shorten_string+ for custom behavior.
- any key +:stack_trace+ has its array truncated. Stack traces are very large,
  but contain short strings. Override +truncate_stack_trace+ for custom behavior.

