### PR TITLE
Add threadlocal request tags, like job tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,25 @@ app = Rack::Builder.new do |builder|
 end
 ```
 
+You can also set tags just for the current request,
+logged out when the request finishes:
+
+```rb
+# WRONG, will result in two messages, "request_finished" will not have 'thing_id' field
+post :delete do
+  thing = lookup_thing
+  thing.delete
+  logger.info "deleted_thing", thing_id: thing.id
+end
+
+# RIGHT, will result in one "request_finished" message, which will include the 'thing_id' field
+post :delete do
+  thing = lookup_thing
+  RequestLogger.set_request_tags(thing_id: thing.id)
+  thing.delete
+end
+```
+
 ### Sidekiq
 
 ```rb

--- a/lib/appydays/loggable/request_logger.rb
+++ b/lib/appydays/loggable/request_logger.rb
@@ -7,7 +7,13 @@ require "appydays/loggable"
 
 ##
 # Rack middleware for request logging, to replace Rack::CommonLogger.
-# NOTE: To get additional log fields, you can subclass this and override `_request_tags`.
+#
+# To get additional log fields, you can subclass this and override +request_tags+.
+#
+# Or you can use +Appydays::Loggable::RequestLogger.set_request_tags+
+# (or call it on your logger subclass) with fields that will accumulate over the request
+# and log out in the "request_finished" message.
+#
 # If you want authenticated user info, make sure you install the middleware
 # after your auth middleware.
 #
@@ -32,6 +38,9 @@ class Appydays::Loggable::RequestLogger
   end
 
   def call(env)
+    # We need to clear request tags in log_finished, but it's possible it didn't run on the last request
+    # so clear the request tags first thing.
+    self.class.request_tags.clear
     began_at = Time.now
     request_fields = self._request_tags(env, began_at)
     status, header, body = SemanticLogger.named_tagged(request_fields) { @app.call(env) }
@@ -48,7 +57,7 @@ class Appydays::Loggable::RequestLogger
   protected def _request_tags(env, began_at)
     req_id = SecureRandom.uuid.to_s
     env["HTTP_TRACE_ID"] ||= req_id
-    return {
+    h = {
       remote_addr: env["HTTP_X_FORWARDED_FOR"] || env["REMOTE_ADDR"] || "-",
       request_started_at: began_at.to_s,
       request_method: env[Rack::REQUEST_METHOD],
@@ -56,22 +65,26 @@ class Appydays::Loggable::RequestLogger
       request_query: env.fetch(Rack::QUERY_STRING, "").empty? ? "" : "?#{env[Rack::QUERY_STRING]}",
       request_id: req_id,
       trace_id: env["HTTP_TRACE_ID"],
-    }.merge(self.request_tags(env))
+    }
+    h.merge!(self.request_tags(env))
+    return h
   end
 
   def request_tags(_env)
     return {}
   end
 
-  protected def log_finished(request_tags, began_at, status, header, exc=nil)
+  protected def log_finished(tags, began_at, status, header, exc=nil)
     elapsed = (Time.now - began_at).to_f
-
-    all_tags = request_tags.merge(
-      response_finished_at: Time.now.to_s,
+    tags.merge!(
+      response_finished_at: Time.now.iso8601,
       response_status: status,
       response_content_length: extract_content_length(header),
       response_ms: elapsed * 1000,
     )
+    class_req_tags = self.class.request_tags
+    tags.merge!(class_req_tags)
+    class_req_tags.clear
 
     level = if status >= 500
               "error"
@@ -81,7 +94,7 @@ class Appydays::Loggable::RequestLogger
       "info"
     end
 
-    self.logger.tagged(all_tags) do
+    SemanticLogger.named_tagged(tags) do
       self.logger.send(level, "request_finished", exc)
     end
     SemanticLogger.flush
@@ -91,4 +104,15 @@ class Appydays::Loggable::RequestLogger
     value = headers[Rack::CONTENT_LENGTH]
     return !value || value.to_s == "0" ? "-" : value
   end
+
+  # Set request tags that get logged out in the "request_finished" message.
+  # This allows you to add useful context to the request without needing
+  # a dedicated log message.
+  # See README for more info.
+  def self.set_request_tags(**tags)
+    Thread.current[:appydays_request_logger_request_tags] ||= {}
+    Thread.current[:appydays_request_logger_request_tags].merge!(tags)
+  end
+
+  def self.request_tags = Thread.current[:appydays_request_logger_request_tags] || {}
 end


### PR DESCRIPTION
Use RequestLogger.set_request_tags,
to work like job tags do in the last release.